### PR TITLE
Fix markdown cannot be saved if containing issue link

### DIFF
--- a/core/helpers/TextParserMarkdown.php
+++ b/core/helpers/TextParserMarkdown.php
@@ -38,9 +38,10 @@
             $this->no_markup = true;
             $this->no_entities = true;
 
-            $text = preg_replace_callback(\thebuggenie\core\helpers\TextParser::getIssueRegex(), array($this, '_parse_issuelink'), $text);
+            $text_parser = new \thebuggenie\core\helpers\TextParser($text);
+            $text = preg_replace_callback($text_parser->getIssueRegex(), array($this, '_parse_issuelink'), $text);
             $text = parent::transform($text);
-            $text = preg_replace_callback(\thebuggenie\core\helpers\TextParser::getMentionsRegex(), array($this, '_parse_mention'), $text);
+            $text = preg_replace_callback($text_parser->getMentionsRegex(), array($this, '_parse_mention'), $text);
             $text = preg_replace_callback(self::getStrikethroughRegex(), array($this, '_parse_strikethrough'), $text);
 
             $parameters = array();


### PR DESCRIPTION
When trying to save a text field with markdown syntax that contains a reference to another issue (e.g. ticket #123) it cannot be saved. This fixes the issue although I'm not sure if it's the best way of doing it or if it has any side effects.
